### PR TITLE
add kubernetes support for skits

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,21 +29,21 @@ var discovery;
 const version_date = '2017-08-01';
 const qs = { aggregation: `[${queryBuilder.aggregations.join(',')}]` };
 if (process.env.service_watson_discovery !== undefined) {
-    // Authentication for starter kit + Kubernetes
-    var service_watson_discovery = JSON.parse(process.env.service_watson_discovery);
-    discovery = new DiscoveryV1({
-        url: service_watson_discovery['url'],
-        username: service_watson_discovery['username'],
-        password: service_watson_discovery['password'],
-        version_date: version_date,
-        qs: qs,
-    });
+  // Authentication for starter kit + Kubernetes
+  var service_watson_discovery = JSON.parse(process.env.service_watson_discovery);
+  discovery = new DiscoveryV1({
+    url: service_watson_discovery['url'],
+    username: service_watson_discovery['username'],
+    password: service_watson_discovery['password'],
+    version_date: version_date,
+    qs: qs,
+  });
 } else {
-    // Credentials will be pulled in from VCAP_SERVICES or .env
-    discovery = new DiscoveryV1({
-        version_date: version_date,
-        qs: qs,
-    });
+  // Credentials will be pulled in from VCAP_SERVICES or .env
+  discovery = new DiscoveryV1({
+    version_date: version_date,
+    qs: qs,
+  });
 }
 
 // pull in all json files to add to discovery collection

--- a/app.js
+++ b/app.js
@@ -25,11 +25,26 @@ const DEFAULT_COLLECTION_NAME = 'data-breaches';
 var environment_id;
 var collection_id;
 
-const discovery = new DiscoveryV1({
-  // uname/pwd will be pulled in from VCAP_SERVICES or .env
-  version_date: '2017-08-01',
-  qs: { aggregation: `[${queryBuilder.aggregations.join(',')}]` },
-});
+var discovery;
+const version_date = '2017-08-01';
+const qs = { aggregation: `[${queryBuilder.aggregations.join(',')}]` };
+if (process.env.service_watson_discovery !== undefined) {
+    // Authentication for starter kit + Kubernetes
+    var service_watson_discovery = JSON.parse(process.env.service_watson_discovery);
+    discovery = new DiscoveryV1({
+        url: service_watson_discovery['url'],
+        username: service_watson_discovery['username'],
+        password: service_watson_discovery['password'],
+        version_date: version_date,
+        qs: qs,
+    });
+} else {
+    // Credentials will be pulled in from VCAP_SERVICES or .env
+    discovery = new DiscoveryV1({
+        version_date: version_date,
+        qs: qs,
+    });
+}
 
 // pull in all json files to add to discovery collection
 var discoveryDocs = [];

--- a/blueprint.json
+++ b/blueprint.json
@@ -42,7 +42,7 @@
     "discovery": "lite"
   },
   "tags": [
-    "watson"
+    "devex"
   ],
   "thumbnailURL": "blueprint/thumbnail.svg",
   "type": "WEB"

--- a/blueprint.json
+++ b/blueprint.json
@@ -42,7 +42,7 @@
     "discovery": "lite"
   },
   "tags": [
-    "devex"
+    "watson"
   ],
   "thumbnailURL": "blueprint/thumbnail.svg",
   "type": "WEB"


### PR DESCRIPTION
This starter kit has been manually tested to work on both Cloud Foundry and Kubernetes as a starter kit. By merging this PR, this repo will be published as a starter kit in the production IBM Cloud console for customers to use.

Starter kits have an arbitrary convention for passing service credentials into a kubernetes pod which the Watson Developer Cloud SDK does not handle, so there's some arbitrary code here to handle that at startup.