### PR TITLE
Travis CI: Both trusty and Node.js 6 are end of life

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-dist: trusty
-node_js: 6
+node_js: node
 script:
   - ./.travis_script.sh
 cache:


### PR DESCRIPTION
Does someone know how to get the Travis CI tests passing with these changes?